### PR TITLE
Add resume page and global header

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import Header from '@/components/Header';
 
 export default function About() {
   return (
@@ -6,26 +6,8 @@ export default function About() {
       className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
-      <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f4f0e7] px-10 py-3">
-        <div className="flex items-center gap-4 text-[#1c180d]">
-          <div className="size-4">
-            {/* Ikon */}
-            <svg viewBox="0 0 48 48" fill="none"><g><path d="M8.578 8.578a18 18 0 104.032 26.781L24 24 8.578 8.578z" fill="currentColor" /></g></svg>
-          </div>
-          <h2 className="text-[#1c180d] text-lg font-bold leading-tight tracking-[-0.015em]">Portfolio</h2>
-        </div>
-        <div className="flex flex-1 justify-end gap-8">
-          <nav className="flex items-center gap-9 text-sm font-medium">
-            <Link href="/" className="text-[#1c180d]">Home</Link>
-            <Link href="/projects" className="text-[#1c180d]">Projects</Link>
-            <Link href="/about" className="text-[#1c180d]">About</Link>
-            <Link href="/contact" className="text-[#1c180d]">Contact</Link>
-          </nav>
-          <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f4c63d] text-[#1c180d] text-sm font-bold leading-normal tracking-[0.015em]">
-            <span className="truncate">Resume</span>
-          </button>
-        </div>
-      </header>
+      {/* Reusable header with Resume link */}
+      <Header />
       <main className="flex flex-1 justify-center py-5 px-40">
         <div className="flex flex-col max-w-[960px] flex-1 layout-content-container">
           <div className="flex p-4 @container">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import Header from '@/components/Header';
 
 export default function Contact() {
   return (
@@ -6,23 +6,8 @@ export default function Contact() {
       className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
-      <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f4f0e7] px-10 py-3">
-        <div className="flex items-center gap-4 text-[#1c180d]">
-          <div className="size-4">
-            {/* Ikon */}
-            <svg viewBox="0 0 48 48" fill="none"><g><path d="M8.578 8.578a18 18 0 104.032 26.781L24 24 8.578 8.578z" fill="currentColor" /></g></svg>
-          </div>
-          <h2 className="text-[#1c180d] text-lg font-bold leading-tight tracking-[-0.015em]">Portfolio</h2>
-        </div>
-        <div className="flex flex-1 justify-end gap-8">
-          <nav className="flex items-center gap-9 text-sm font-medium">
-            <Link href="/" className="text-[#1c180d]">Home</Link>
-            <Link href="/projects" className="text-[#1c180d]">Projects</Link>
-            <Link href="/about" className="text-[#1c180d]">About</Link>
-            <Link href="/contact" className="text-[#1c180d]">Contact</Link>
-          </nav>
-        </div>
-      </header>
+      {/* Reusable header with Resume link */}
+      <Header />
       <main className="flex flex-1 justify-center py-5 px-40">
         <div className="flex flex-col max-w-[960px] flex-1 layout-content-container">
           <div className="flex p-4 @container">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+// Global header with Resume link
+import Header from '@/components/Header'
 
 export default function Home() {
   return (
@@ -6,6 +8,8 @@ export default function Home() {
       className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden group/design-root"
       style={{ fontFamily: 'Plus Jakarta Sans, \"Noto Sans\", sans-serif' }}
     >
+      {/* Site header */}
+      <Header />
       <div className="flex flex-1 justify-center py-5 px-4">
         <div className="flex flex-col w-full max-w-[960px] flex-1 layout-content-container">
           <div className="@container">

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+import Header from '@/components/Header'
 import { getProjectData, getProjectSlugs } from '@/lib/projects'
 import { notFound } from 'next/navigation'
 
@@ -15,9 +16,11 @@ export default async function ProjectPage({ params }: { params: any }) {
   if (!project) return notFound();
   return (
     <div
-      className="min-h-screen bg-[#fcfbf8] flex justify-center"
+      className="min-h-screen bg-[#fcfbf8] flex flex-col items-center"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
+      {/* Reusable header with Resume link */}
+      <Header />
     <main className="max-w-2xl p-8 space-y-6">
       <h1 className="text-3xl font-bold">{project.name}</h1>
       {project.description && <p>{project.description}</p>}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import Header from '@/components/Header'
 import { getAllProjects } from '@/lib/projects'
 
 export default async function ProjectsPage() {
@@ -8,26 +9,8 @@ export default async function ProjectsPage() {
       className="min-h-screen flex flex-col bg-[#fcfbf8]"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
-      <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f4f0e7] px-10 py-3">
-        <div className="flex items-center gap-4 text-[#1c180d]">
-          <div className="size-4">
-            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <g clipPath="url(#clip0)">
-                <path d="M8.578 8.578a18 18 0 104.032 26.781L24 24 8.578 8.578z" fill="currentColor" />
-              </g>
-              <defs>
-                <clipPath id="clip0"><rect width="48" height="48" fill="white" /></clipPath>
-              </defs>
-            </svg>
-          </div>
-          <h2 className="text-[#1c180d] text-lg font-bold leading-tight tracking-[-0.015em]">Portfolio</h2>
-        </div>
-        <nav className="flex flex-1 justify-end gap-9 text-sm font-medium">
-          <Link href="/about" className="text-[#1c180d]">About</Link>
-          <Link href="/projects" className="text-[#1c180d]">Projects</Link>
-          <Link href="/contact" className="text-[#1c180d]">Contact</Link>
-        </nav>
-      </header>
+      {/* Reusable header with Resume link */}
+      <Header />
       <main className="flex-1 max-w-[960px] w-full mx-auto p-8 space-y-6">
         <h1 className="text-[32px] font-bold leading-tight tracking-light text-[#1c180d]">My Projects</h1>
         <p className="text-[#9c8749] text-sm">A selection of my most recent work.</p>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,0 +1,28 @@
+import Header from '@/components/Header'
+import Link from 'next/link'
+
+export default function ResumePage() {
+  return (
+    <div
+      className="min-h-screen flex flex-col bg-[#fcfbf8]"
+      style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
+    >
+      {/* Header with resume navigation */}
+      <Header />
+      <main className="flex flex-col items-center flex-1 p-4 gap-4 max-w-4xl w-full mx-auto">
+        {/* Display CV PDF inline */}
+        <object data="/cv.pdf" type="application/pdf" className="w-full h-[80vh]">
+          <p>Your browser does not support PDFs. <Link href="/cv.pdf">Download PDF</Link>.</p>
+        </object>
+        {/* Download link below the viewer */}
+        <a
+          href="/cv.pdf"
+          download
+          className="flex items-center justify-center bg-[#f4c63d] text-[#1c180d] font-bold rounded-lg h-10 px-4"
+        >
+          Download PDF
+        </a>
+      </main>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+
+/** Global header displayed on all pages */
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f4f0e7] px-10 py-3">
+      <div className="flex items-center gap-4 text-[#1c180d]">
+        <div className="size-4">
+          {/* Logo icon */}
+          <svg viewBox="0 0 48 48" fill="none"><g><path d="M8.578 8.578a18 18 0 104.032 26.781L24 24 8.578 8.578z" fill="currentColor" /></g></svg>
+        </div>
+        <h2 className="text-[#1c180d] text-lg font-bold leading-tight tracking-[-0.015em]">Portfolio</h2>
+      </div>
+      <div className="flex flex-1 justify-end gap-8">
+        <nav className="flex items-center gap-9 text-sm font-medium">
+          <Link href="/" className="text-[#1c180d]">Home</Link>
+          <Link href="/projects" className="text-[#1c180d]">Projects</Link>
+          <Link href="/about" className="text-[#1c180d]">About</Link>
+          <Link href="/contact" className="text-[#1c180d]">Contact</Link>
+        </nav>
+        {/* Resume button now available globally */}
+        <Link
+          href="/resume"
+          className="flex min-w-[84px] max-w-[480px] items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f4c63d] text-[#1c180d] text-sm font-bold leading-normal tracking-[0.015em]"
+        >
+          <span className="truncate">Resume</span>
+        </Link>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- create reusable `Header` component
- add header to all pages and include Resume link
- create new `/resume` page with embedded PDF viewer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684da21afec08333932e14e45e65067e