### PR TITLE
Support external projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ This is a portfolio site built with Next.js.
 
 ## Adding projects
 
-Projects live in the `projects` directory. To add a new project simply create a
-folder inside `projects` and add a `project.json` file:
+Projects live in the `projects` directory. To add an **internal** project create
+a folder inside `projects` and add a `project.json` file:
 
 ```json
 {
@@ -14,6 +14,22 @@ folder inside `projects` and add a `project.json` file:
 
 Optionally you can include a `README.md` or `index.js` file which will be shown
 on the project page.
+
+External projects can be added by dropping a single `project-name.json` file
+directly inside the `projects` folder. Example:
+
+```json
+{
+  "name": "External App",
+  "description": "Hosted elsewhere",
+  "external": true,
+  "link": "https://example.com",
+  "demoImage": "https://placehold.co/600x400",
+  "tech": ["Next.js", "TypeScript"],
+  "tags": ["demo"],
+  "featured": true
+}
+```
 
 ## Getting Started
 

--- a/projects/portfoliohub.json
+++ b/projects/portfoliohub.json
@@ -1,0 +1,10 @@
+{
+  "name": "PortfolioHub Repo",
+  "description": "GitHub repository for this site",
+  "external": true,
+  "link": "https://github.com/example/portfolioHub",
+  "demoImage": "https://placehold.co/600x400",
+  "tech": ["Next.js", "TypeScript"],
+  "tags": ["portfolio", "open-source"],
+  "featured": true
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,12 @@
 import Link from 'next/link'
 // Global header with Resume link
 import Header from '@/components/Header'
+import { getAllProjects } from '@/lib/projects'
+import ProjectCard from '@/components/ProjectCard'
 
-export default function Home() {
+export default async function Home() {
+  const projects = await getAllProjects()
+  const featured = projects.filter((p) => p.featured)
   return (
     <div
       className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden group/design-root"
@@ -38,6 +42,16 @@ export default function Home() {
               </div>
             </div>
           </div>
+          {featured.length > 0 && (
+            <section className="my-8 space-y-4">
+              <h2 className="text-xl font-bold">Featured Projects</h2>
+              <div className="grid gap-6 md:grid-cols-2">
+                {featured.map((p) => (
+                  <ProjectCard key={p.slug} project={p} />
+                ))}
+              </div>
+            </section>
+          )}
           <footer className="flex flex-col gap-6 px-5 py-10 text-center @container">
             <div className="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
               <Link href="/about" className="text-[#9c8749] text-base min-w-40">

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,19 +1,19 @@
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import Header from '@/components/Header'
-import { getProjectData, getProjectSlugs } from '@/lib/projects'
+import { getAllProjects, getProjectData } from '@/lib/projects'
 import { notFound } from 'next/navigation'
 
 export async function generateStaticParams() {
-  const slugs = await getProjectSlugs()
-  return slugs.map((slug) => ({ slug }))
+  const projects = await getAllProjects()
+  return projects.filter(p => !p.external).map((p) => ({ slug: p.slug }))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function ProjectPage({ params }: { params: any }) {
   const { slug } = await params;
   const project = await getProjectData(slug);
-  if (!project) return notFound();
+  if (!project || project.external) return notFound();
   return (
     <div
       className="min-h-screen bg-[#fcfbf8] flex flex-col items-center"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link'
 import Header from '@/components/Header'
 import { getAllProjects } from '@/lib/projects'
+import ProjectCard from '@/components/ProjectCard'
 
 export default async function ProjectsPage() {
   const projects = await getAllProjects()
@@ -15,25 +15,9 @@ export default async function ProjectsPage() {
         <h1 className="text-[32px] font-bold leading-tight tracking-light text-[#1c180d]">My Projects</h1>
         <p className="text-[#9c8749] text-sm">A selection of my most recent work.</p>
         <div className="grid gap-6 md:grid-cols-2">
-          {projects.map((project) => {
-            const preview = project.readme || project.demoCode || ''
-            const snippet = preview.split('\n').slice(0, 4).join('\n')
-            return (
-              <Link
-                href={`/projects/${project.slug}`}
-                key={project.slug}
-                className="block p-4 border rounded-lg shadow bg-white/70 hover:bg-white"
-              >
-                <h2 className="text-base font-medium text-[#1c180d] mb-1">{project.name}</h2>
-                {project.description && <p className="mb-2 text-sm text-[#9c8749]">{project.description}</p>}
-                {snippet && (
-                  <pre className="text-xs bg-gray-100 p-2 rounded whitespace-pre-wrap">
-                    <code>{snippet}</code>
-                  </pre>
-                )}
-              </Link>
-            )
-          })}
+          {projects.map((project) => (
+            <ProjectCard key={project.slug} project={project} />
+          ))}
         </div>
       </main>
       <footer className="flex flex-col items-center gap-6 px-5 py-10 text-center">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { ProjectData } from '@/lib/projects'
+
+export default function ProjectCard({ project }: { project: ProjectData }) {
+  const preview = project.readme || project.demoCode || ''
+  const snippet = preview.split('\n').slice(0, 4).join('\n')
+
+  if (project.external) {
+    return (
+      <div className="block p-4 border rounded-lg shadow bg-white/70" key={project.slug}>
+        {project.demoImage && (
+          <div className="mb-2">
+            <Image src={project.demoImage} alt="demo" width={400} height={200} className="w-full h-48 object-cover rounded" />
+          </div>
+        )}
+        <h2 className="text-base font-medium text-[#1c180d] mb-1">{project.name}</h2>
+        {project.description && <p className="mb-2 text-sm text-[#9c8749]">{project.description}</p>}
+        {project.tech && (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {project.tech.map((t) => (
+              <span key={t} className="text-xs bg-gray-200 px-2 py-1 rounded">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+        {project.link && (
+          <a
+            href={project.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block mt-2 px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            Visit
+          </a>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Link
+      href={`/projects/${project.slug}`}
+      className="block p-4 border rounded-lg shadow bg-white/70 hover:bg-white"
+    >
+      <h2 className="text-base font-medium text-[#1c180d] mb-1">{project.name}</h2>
+      {project.description && <p className="mb-2 text-sm text-[#9c8749]">{project.description}</p>}
+      {snippet && (
+        <pre className="text-xs bg-gray-100 p-2 rounded whitespace-pre-wrap">
+          <code>{snippet}</code>
+        </pre>
+      )}
+    </Link>
+  )
+}

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -4,6 +4,12 @@ import path from 'path';
 export interface ProjectMeta {
   name: string;
   description?: string;
+  external?: boolean;
+  link?: string;
+  demoImage?: string;
+  tech?: string[];
+  tags?: string[];
+  featured?: boolean;
 }
 
 export interface ProjectData extends ProjectMeta {
@@ -14,8 +20,13 @@ export interface ProjectData extends ProjectMeta {
 
 const PROJECTS_DIR = path.join(process.cwd(), 'projects');
 
-async function isDirectory(source: string) {
-  return (await fs.stat(source)).isDirectory();
+async function exists(p: string) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function getProjectSlugs(): Promise<string[]> {
@@ -27,15 +38,25 @@ export async function getProjectSlugs(): Promise<string[]> {
   const names = await fs.readdir(PROJECTS_DIR);
   const slugs: string[] = [];
   for (const name of names) {
-    if (await isDirectory(path.join(PROJECTS_DIR, name))) {
+    const full = path.join(PROJECTS_DIR, name);
+    const stat = await fs.stat(full);
+    if (stat.isDirectory()) {
       slugs.push(name);
+    } else if (stat.isFile() && name.endsWith('.json')) {
+      slugs.push(name.replace(/\.json$/, ''));
     }
   }
   return slugs;
 }
 
 export async function getProjectMeta(slug: string): Promise<ProjectMeta> {
-  const file = path.join(PROJECTS_DIR, slug, 'project.json');
+  const dirFile = path.join(PROJECTS_DIR, slug, 'project.json');
+  try {
+    const raw = await fs.readFile(dirFile, 'utf8');
+    return JSON.parse(raw) as ProjectMeta;
+  } catch {}
+
+  const file = path.join(PROJECTS_DIR, `${slug}.json`);
   const raw = await fs.readFile(file, 'utf8');
   return JSON.parse(raw) as ProjectMeta;
 }
@@ -49,18 +70,20 @@ export async function getAllProjects(): Promise<ProjectData[]> {
 export async function getProjectData(slug: string): Promise<ProjectData | null> {
   try {
     const meta = await getProjectMeta(slug);
-    const readmePath = path.join(PROJECTS_DIR, slug, 'README.md');
-    const demoPath = path.join(PROJECTS_DIR, slug, 'index.js');
-    let readme: string | undefined = undefined;
-    let demoCode: string | undefined = undefined;
+    const dir = path.join(PROJECTS_DIR, slug);
+    let readme: string | undefined;
+    let demoCode: string | undefined;
 
-    try {
-      readme = await fs.readFile(readmePath, 'utf8');
-    } catch {}
-
-    try {
-      demoCode = await fs.readFile(demoPath, 'utf8');
-    } catch {}
+    if (await exists(dir)) {
+      const readmePath = path.join(dir, 'README.md');
+      const demoPath = path.join(dir, 'index.js');
+      try {
+        readme = await fs.readFile(readmePath, 'utf8');
+      } catch {}
+      try {
+        demoCode = await fs.readFile(demoPath, 'utf8');
+      } catch {}
+    }
 
     return {
       slug,


### PR DESCRIPTION
## Summary
- allow project.json files directly in `projects` for external entries
- expose new metadata fields (external, link, demoImage, tech, tags, featured)
- create `ProjectCard` component to display projects
- render featured projects on the home page
- show project cards for both internal and external projects
- skip external projects when generating static params
- document the new project JSON format

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e938dd230833387bab269e1d4c80f