### PR TITLE
Add Academic Work showcase page

### DIFF
--- a/public/academic/placeholder.pdf
+++ b/public/academic/placeholder.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 72 72 Td (Hello, PDF!) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000062 00000 n 
+0000000115 00000 n 
+0000000249 00000 n 
+0000000362 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+439
+%%EOF

--- a/src/app/academic/page.tsx
+++ b/src/app/academic/page.tsx
@@ -1,0 +1,44 @@
+import Header from '@/components/Header'
+import AcademicCard from '@/components/AcademicCard'
+import { getAcademicWorks, AcademicWork } from '@/lib/academic'
+
+export default async function AcademicPage() {
+  const works = await getAcademicWorks()
+  const featured = works.filter((w) => w.featured)
+  const others = works.filter((w) => !w.featured)
+
+  return (
+    <div
+      className="min-h-screen flex flex-col bg-[#fcfbf8]"
+      style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
+    >
+      <Header />
+      <main className="flex-1 max-w-[960px] w-full mx-auto p-8 space-y-6">
+        <h1 className="text-[32px] font-bold leading-tight tracking-light text-[#1c180d]">Academic Work</h1>
+        {works.length === 0 && (
+          <p className="text-[#9c8749]">Coming soon.</p>
+        )}
+        {featured.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="text-xl font-bold">Featured</h2>
+            <div className="grid gap-6 md:grid-cols-2">
+              {featured.map((work: AcademicWork) => (
+                <AcademicCard key={work.name} work={work} />
+              ))}
+            </div>
+          </section>
+        )}
+        {others.length > 0 && (
+          <section className="space-y-4">
+            {featured.length > 0 && <h2 className="text-xl font-bold">More Works</h2>}
+            <div className="grid gap-6 md:grid-cols-2">
+              {others.map((work: AcademicWork) => (
+                <AcademicCard key={work.name} work={work} />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/components/AcademicCard.tsx
+++ b/src/components/AcademicCard.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image'
+import { AcademicWork } from '@/lib/academic'
+
+export default function AcademicCard({ work }: { work: AcademicWork }) {
+  return (
+    <div className="p-4 border rounded-lg shadow bg-white/70 hover:bg-white transition" key={work.name}>
+      {work.demoImage && (
+        <div className="mb-2">
+          <Image src={work.demoImage} alt="thumbnail" width={400} height={200} className="w-full h-48 object-cover rounded" />
+        </div>
+      )}
+      <h2 className="text-base font-medium text-[#1c180d] mb-1">{work.name}</h2>
+      {work.description && <p className="mb-2 text-sm text-[#9c8749]">{work.description}</p>}
+      {work.tech && (
+        <div className="flex flex-wrap gap-2 mb-2">
+          {work.tech.map((t) => (
+            <span key={t} className="text-xs bg-gray-200 px-2 py-1 rounded">
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      {work.link && (
+        <a
+          href={work.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Read More
+        </a>
+      )}
+      {work.pdf && (
+        <a
+          href={work.pdf}
+          download
+          className="inline-block mt-2 ml-2 px-3 py-1 bg-green-600 text-white rounded"
+        >
+          Download PDF
+        </a>
+      )}
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ export default function Header() {
         <nav className="flex items-center gap-9 text-sm font-medium">
           <Link href="/" className="text-[#1c180d]">Home</Link>
           <Link href="/projects" className="text-[#1c180d]">Projects</Link>
+          <Link href="/academic" className="text-[#1c180d]">Academic Work</Link>
           <Link href="/about" className="text-[#1c180d]">About</Link>
           <Link href="/contact" className="text-[#1c180d]">Contact</Link>
         </nav>

--- a/src/data/academic.json
+++ b/src/data/academic.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Deep Learning for Nature",
+    "description": "Using neural networks to classify wildlife images",
+    "demoImage": "https://placehold.co/600x400",
+    "link": "https://example.com/paper.pdf",
+    "pdf": "/academic/placeholder.pdf",
+    "tech": ["Python", "TensorFlow"],
+    "featured": true
+  },
+  {
+    "name": "Sustainable Computing Report",
+    "description": "Energy efficient algorithms for data centers",
+    "demoImage": "https://placehold.co/600x400",
+    "link": "https://example.com/report.pdf",
+    "pdf": "/academic/placeholder.pdf",
+    "tech": ["Go", "Distributed Systems"]
+  }
+]

--- a/src/lib/academic.ts
+++ b/src/lib/academic.ts
@@ -1,0 +1,15 @@
+import data from '../data/academic.json'
+
+export interface AcademicWork {
+  name: string
+  description?: string
+  demoImage?: string
+  link?: string
+  pdf?: string
+  tech?: string[]
+  featured?: boolean
+}
+
+export async function getAcademicWorks(): Promise<AcademicWork[]> {
+  return data as AcademicWork[]
+}


### PR DESCRIPTION
## Summary
- add `AcademicWork` data source and fetching utils
- create `AcademicCard` component for listing papers
- add new page `/academic` with featured/regular layout
- link "Academic Work" from the header navigation
- add PDF download support for academic items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e9c56010c8333aa04e3be01bc4c77