### PR TITLE
Add sitewide desert gradient

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,7 +3,7 @@ import Header from '@/components/Header';
 export default function About() {
   return (
     <div
-      className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden"
+      className="relative flex min-h-screen flex-col overflow-x-hidden"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
       {/* Reusable header with Resume link */}

--- a/src/app/academic/page.tsx
+++ b/src/app/academic/page.tsx
@@ -9,7 +9,7 @@ export default async function AcademicPage() {
 
   return (
     <div
-      className="min-h-screen flex flex-col bg-[#fcfbf8]"
+      className="min-h-screen flex flex-col"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
       <Header />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,7 +3,7 @@ import Header from '@/components/Header';
 export default function Contact() {
   return (
     <div
-      className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden"
+      className="relative flex min-h-screen flex-col overflow-x-hidden"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
       {/* Reusable header with Resume link */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 
 body {
-  background-color: #fcfbf8;
   color: #1c180d;
   font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="antialiased font-sans bg-[#fcfbf8] text-[#1c180d]">
+      <body className="antialiased font-sans text-[#1c180d] bg-desert-gradient from-desert-start to-desert-end min-h-screen">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default async function Home() {
   const featured = projects.filter((p) => p.featured)
   return (
     <div
-      className="relative flex min-h-screen flex-col bg-[#fcfbf8] overflow-x-hidden group/design-root"
+      className="relative flex min-h-screen flex-col overflow-x-hidden group/design-root"
       style={{ fontFamily: 'Plus Jakarta Sans, \"Noto Sans\", sans-serif' }}
     >
       {/* Site header */}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -6,7 +6,7 @@ export default async function ProjectsPage() {
   const projects = await getAllProjects()
   return (
     <div
-      className="min-h-screen flex flex-col bg-[#fcfbf8]"
+      className="min-h-screen flex flex-col"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
       {/* Reusable header with Resume link */}

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export default function ResumePage() {
   return (
     <div
-      className="min-h-screen flex flex-col bg-[#fcfbf8]"
+      className="min-h-screen flex flex-col"
       style={{ fontFamily: 'Plus Jakarta Sans, "Noto Sans", sans-serif' }}
     >
       {/* Header with resume navigation */}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,19 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        'desert-start': '#4b5766',
+        'desert-end': '#2c3e50',
+      },
+      backgroundImage: {
+        'desert-gradient': 'linear-gradient(to bottom, var(--tw-gradient-stops))',
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- use custom gradient colors for the site background
- apply global gradient and remove page-level background colors
- export tailwind config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ed67727c48333a9c27409742d98a3